### PR TITLE
does not prepend lib to an artifact if not necessary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 group = 'com.nabilhachicha'
-version = '0.1.1'
+version = '0.1.2'
 
 modifyPom {
     project {

--- a/src/main/groovy/com/nabilhachicha/nativedependencies/task/NativeDependenciesResolverTask.groovy
+++ b/src/main/groovy/com/nabilhachicha/nativedependencies/task/NativeDependenciesResolverTask.groovy
@@ -144,7 +144,11 @@ class NativeDependenciesResolverTask extends DefaultTask {
                     "src"+File.separator+"main"+File.separator+
                     "jniLibs"+File.separator+"$architecture"
             rename { fileName ->
-                     "lib" + depName+ ".so"
+                    if (depName.startsWith("lib")) {
+                        depName + ".so"
+                    } else {
+                        "lib" + depName+ ".so"
+                    }
             }
         }
     }


### PR DESCRIPTION
Hello, Great plugin. I added a quick fix to not prepend 'lib' to an artifact if it does not need it. This was needed for an artifact in Maven Central.

http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22libjingle-peerconnection-so%22

Thanks!
