### PR TITLE
force older Java version to avoid #9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,3 +131,8 @@ bintray {
 task wrapper(type: Wrapper) {
     gradleVersion = '2.2'
 }
+
+compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_6
+    targetCompatibility JavaVersion.VERSION_1_6
+}


### PR DESCRIPTION
I have not tested it (no idea about gradle plugin development) but maybe it works
